### PR TITLE
Fixed build, updated to 0.9.26 along the way

### DIFF
--- a/com.gitlab.sat_metalab.Splash.json
+++ b/com.gitlab.sat_metalab.Splash.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.gitlab.sat_metalab.Splash",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "splash",
     "rename-desktop-file": "splash.desktop",
@@ -86,7 +86,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.com/sat-metalab/shmdata.git",
+                    "url": "https://gitlab.com/sat-mtl/tools/shmdata.git",
                     "tag": "1.3.68",
                     "commit": "66513e5fef0a6fdad986455370a80f272f1745c2"
                 }
@@ -95,11 +95,10 @@
         {
             "name": "splash",
             "buildsystem": "simple",
-            "config-opts": [
-                "-DBUILD_GENERIC_ARCH=ON"
-            ],
             "build-commands": [
-                "./make_deps.sh",
+                "git submodule update --init --recursive",
+                "mkdir -p external/third_parties",
+                "./external/build_zmq.sh",
                 "cmake -DBUILD_GENERIC_ARCH=ON -DWITH_LTO=ON -DCMAKE_INSTALL_PREFIX=/app .",
                 "make -j$(if [[ -z ${FLATPAK_BUILD_N_JOBS} ]]; then echo $(nproc); else echo ${FLATPAK_BUILD_N_JOBS}; fi)",
                 "make install"
@@ -107,9 +106,9 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.com/sat-metalab/splash.git",
-                    "tag": "0.9.24",
-                    "commit": "985a99218e96c2a6580cd443e0c79f148a7a7076"
+                    "url": "https://gitlab.com/sat-mtl/tools/splash/splash.git",
+                    "tag": "0.9.26",
+                    "commit": "86298c68037d826db0e05767dcce3fd8d5ab3085"
                 }
             ]
         }

--- a/com.gitlab.sat_metalab.Splash.json
+++ b/com.gitlab.sat_metalab.Splash.json
@@ -17,7 +17,6 @@
         "/bin/gsl_*",
         "/bin/opencv_*",
         "/include",
-        "/lib/debug",
         "/share/OpenCV",
         "/share/info",
         "/share/man",
@@ -28,8 +27,13 @@
     "modules": [
         {
             "name": "opencv",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "builddir": true,
+            "config-opts": [
+                "-DBUILD_PERF_TEST=OFF",
+                "-DBUILD_TESTS=OFF",
+                "-DBUILD_EXAMPLES=OFF"
+            ],
             "sources": [
                 {
                     "type": "git",
@@ -41,7 +45,7 @@
         },
         {
             "name": "portaudio",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "git",
@@ -67,7 +71,7 @@
         },
         {
             "name": "jsoncpp",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "git",
@@ -79,7 +83,7 @@
         },
         {
             "name": "shmdata",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DWITH_PYTHON=OFF"
             ],

--- a/com.gitlab.sat_metalab.Splash.json
+++ b/com.gitlab.sat_metalab.Splash.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.gitlab.sat_metalab.Splash",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "splash",
     "rename-desktop-file": "splash.desktop",
@@ -125,8 +125,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/sat-mtl/tools/splash/splash.git",
-                    "tag": "0.9.26",
-                    "commit": "86298c68037d826db0e05767dcce3fd8d5ab3085"
+                    "tag": "0.9.28",
+                    "commit": "5715204110b9d8a2a5905155a695754511c8f0ac"
                 }
             ]
         }

--- a/com.gitlab.sat_metalab.Splash.json
+++ b/com.gitlab.sat_metalab.Splash.json
@@ -97,15 +97,29 @@
             ]
         },
         {
+            "name": "zmq",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DWITH_LIBSODIUM=OFF",
+                "-DWITH_TLS=OFF",
+                "-DENABLE_WS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/zeromq/libzmq.git",
+                    "tag": "v4.3.4",
+                    "commit": "4097855ddaaa65ed7b5e8cb86d143842a594eebd"
+                }
+            ]
+        },
+        {
             "name": "splash",
-            "buildsystem": "simple",
-            "build-commands": [
-                "git submodule update --init --recursive",
-                "mkdir -p external/third_parties",
-                "./external/build_zmq.sh",
-                "cmake -DBUILD_GENERIC_ARCH=ON -DWITH_LTO=ON -DCMAKE_INSTALL_PREFIX=/app .",
-                "make -j$(if [[ -z ${FLATPAK_BUILD_N_JOBS} ]]; then echo $(nproc); else echo ${FLATPAK_BUILD_N_JOBS}; fi)",
-                "make install"
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_GENERIC_ARCH=ON",
+                "-DWITH_LTO=ON"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This fixes the build of the package. Along the way I:
* made sure to use ffmpeg from the runtime
* reverted to runtime 21.08 because of a build issue I was not able to fix yet (and which does not happen in similar situation with gcc 12 on Archlinux)
* updated some URLs.