### PR TITLE
Set this package as end-of-life, redirecting to new package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Splash Flathub repository
 =========================
 
+**NOTE**: this package is deprecated, use `xyz.splashmapper.Splash` instead.
+
 To build the package manually:
 
 ```bash

--- a/com.gitlab.sat_metalab.Splash.json
+++ b/com.gitlab.sat_metalab.Splash.json
@@ -1,4 +1,6 @@
 {
+    "end-of-life": "The application has been renamed to xyz.splashmapper.Splash.",
+    "end-of-life-rebase": "xyz.splashmapper.Splash",
     "app-id": "com.gitlab.sat_metalab.Splash",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "22.08",


### PR DESCRIPTION
The base URL for this software has changed, and the application ID has been updated to follow this change.

So this package is now deprecated in favor of xyz.splashmapper.Splash.